### PR TITLE
Add support for Task-based concurrency and async / await

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Allows you to enforce that methods or property accessors are called in a specifi
 * Provides loops which allow you to group calls into a recurring group.
 * Allows you to specify the the number of times a loop should be expected.
 * Calls that are expected to be called in sequence can be inter-mixed with calls that are expected in any order.
-* Multi-threaded support.
+* Multi-threaded support, as well as support for `Task`-based concurrency and `async` / `await`.
 
 ## To Use ##
 
@@ -27,7 +27,7 @@ During mock execution, any violation of sequencing will throw a `SequenceExcepti
 When the `Sequence` is disposed any sequencing expectations that were not fulfilled will cause a 
 `SequenceException` to be thrown.
 
-There can only be one `Sequence` active per thread. An attempt to create more than one will throw a `SequenceUsageException`.
+Sequences cannot be nested. An attempt to create more than one will throw a `SequenceUsageException`.
 
 ### Steps ###
 
@@ -72,6 +72,19 @@ using (Sequence.Create())
     // Logic that triggers the above method calls should be done here.
     …
 }
+```
+
+### Support for `Task`-based concurrency and `async` / `await` ###
+
+This library was originally designed with explicit multi-threading in mind. By default, the currently
+active `Sequence` is tied to (and only accessible on) the specific thread that created it.
+Unfortunately, this behaviour does not play well together with `Task`-based concurrency.
+
+You can change Moq.Sequences' behavior to a mode that is compatible with `Task`-based concurrency
+and `async` / `await` by doing the following before any of your tests execute:
+
+```csharp
+Sequence.ContextMode = SequenceContextMode.Async;
 ```
 
 ## To Build ##

--- a/src/Moq.Sequences.Tests/AsyncTest.cs
+++ b/src/Moq.Sequences.Tests/AsyncTest.cs
@@ -1,0 +1,92 @@
+﻿using NUnit.Framework;
+using System.Threading.Tasks;
+
+namespace Moq.Sequences.Tests
+{
+    public class AsyncTest
+    {
+        [SetUp]
+        public void SwitchToAsyncContextMode()
+        {
+            Sequence.ContextMode = SequenceContextMode.Async;
+        }
+
+        [TearDown]
+        public void ResetToThreadContextMode()
+        {
+            Sequence.ContextMode = SequenceContextMode.Thread;
+        }
+
+        [Test]
+        public async Task Sequence_verification_works_after_await()
+        {
+            using (Sequence.Create())
+            {
+                var fooMock = new Mock<IFoo>();
+                fooMock.Setup(f => f.Fooxiate()).InSequence();
+
+                var barMock = new Mock<IBar>();
+                barMock.Setup(b => b.Baronize()).InSequence();
+
+                var sut = new SomeClass(fooMock.Object, barMock.Object);
+
+                var result = await sut.DoMyStuffAsync();
+
+                Assert.AreEqual("someString", result);
+            }
+        }
+
+        [Test]
+        public async Task Cannot_create_new_sequence_after_await_when_another_sequence_should_be_active()
+        {
+            using (Sequence.Create())
+            {
+                var fooMock = new Mock<IFoo>();
+                fooMock.Setup(f => f.Fooxiate()).InSequence();
+
+                var barMock = new Mock<IBar>();
+                barMock.Setup(b => b.Baronize()).InSequence();
+
+                var sut = new SomeClass(fooMock.Object, barMock.Object);
+
+                var result = await sut.DoMyStuffAsync();
+
+                Assert.Throws<SequenceUsageException>(() => Sequence.Create());
+            }
+        }
+
+        public class SomeClass
+        {
+            private readonly IFoo _foo;
+            private readonly IBar _bar;
+
+            public SomeClass(IFoo foo, IBar bar)
+            {
+                _bar = bar;
+                _foo = foo;
+            }
+
+            public async Task<string> DoMyStuffAsync()
+            {
+                return await Task.Run(() => DoMyStuff());
+            }
+
+            private string DoMyStuff()
+            {
+                _foo.Fooxiate();
+                _bar.Baronize();
+                return "someString";
+            }
+        }
+
+        public interface IBar
+        {
+            void Baronize();
+        }
+
+        public interface IFoo
+        {
+            void Fooxiate();
+        }
+    }
+}

--- a/src/Moq.Sequences.Tests/Moq.Sequences.Tests.csproj
+++ b/src/Moq.Sequences.Tests/Moq.Sequences.Tests.csproj
@@ -35,6 +35,7 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AsyncTest.cs" />
     <Compile Include="BlogPresenterTest.cs" />
     <Compile Include="LoopTest.cs" />
     <Compile Include="SequenceTest.cs" />

--- a/src/Moq.Sequences/Moq.Sequences.csproj
+++ b/src/Moq.Sequences/Moq.Sequences.csproj
@@ -18,6 +18,13 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <DefineConstants>$(DefineConstants);FEATURE_CALLCONTEXT</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <DefineConstants>$(DefineConstants);FEATURE_ASYNCLOCAL</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.7.0" />
   </ItemGroup>

--- a/src/Moq.Sequences/Sequence.cs
+++ b/src/Moq.Sequences/Sequence.cs
@@ -7,14 +7,29 @@ namespace Moq.Sequences
         private static readonly Times anyNumberOfTimes = Times.Between(0, Int32.MaxValue, Range.Inclusive);
         private bool invocationExceptionThrown;
 
-        [ThreadStatic]
-        private static Sequence instance;
+        private static Sequence Instance
+        {
+            get => Sequence.ContextMode.ActiveSequence;
+            set => Sequence.ContextMode.ActiveSequence = value;
+        }
 
-        internal static Sequence Instance { get { return instance; } }
+        private static SequenceContextMode contextMode = SequenceContextMode.Thread;
+
+        /// <summary>
+        /// Gets or sets the context mode that determines how sequences behave in the presence of
+        /// concurrency or asynchrony. This is a global setting that will affect all sequences.
+        /// It is recommended that you set the context mode only once. The default is
+        /// <see cref="SequenceContextMode.Thread"/>.
+        /// </summary>
+        public static SequenceContextMode ContextMode
+        {
+            get => Sequence.contextMode;
+            set => Sequence.contextMode = value ?? throw new ArgumentNullException(nameof(value));
+        }
 
         private Sequence() : base(Times.AtMostOnce())
         {
-            instance = this;
+            Instance = this;
         }
 
         public static Sequence Create()
@@ -74,7 +89,7 @@ namespace Moq.Sequences
 
         protected override void DoDisposalChecks()
         {
-            instance = null;
+            Instance = null;
 
             if (invocationExceptionThrown)
                 return;

--- a/src/Moq.Sequences/SequenceContextMode.cs
+++ b/src/Moq.Sequences/SequenceContextMode.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+#if FEATURE_CALLCONTEXT
+using System.Runtime.Remoting.Messaging;
+#elif FEATURE_ASYNCLOCAL
+using System.Threading;
+#endif
+using System.Threading.Tasks;
+
+namespace Moq.Sequences
+{
+    /// <summary>
+    /// Determines how <see cref="Sequence"/>s behave in the presence of concurrency or asynchrony.
+    /// You can choose a context mode by setting the static <see cref="Sequence.ContextMode"/> property.
+    /// Note that this is a global setting; you cannot set a context mode for an individual sequence.
+    /// </summary>
+    public abstract class SequenceContextMode
+    {
+        /// <summary>
+        /// With this mode, each sequence is restricted (and only visible) to the thread that created it.
+        /// This context mode will not work well together with the Task Parallel Library (TPL) or
+        /// <see langword="async"/> / <see langword="await"/>. However, for backwards compatibility, it
+        /// is the default mode.
+        /// </summary>
+        public static SequenceContextMode Thread { get; } = new SequenceThreadContextMode();
+
+        /// <summary>
+        /// With this mode, sequences "flow" with the current call context, even across async boundaries.
+        /// This means that you can create a sequence in an <see langword="async"/> method and it will
+        /// still be accessible after any <see langword="await"/>s. Sequences will also flow from parent
+        /// to child threads or <see cref="Task"/>s. This is the recommended mode if your code makes use
+        /// of the Task Parallel Library (TPL) or <see langword="async"/> / <see langword="await"/>.
+        /// You need to opt in to this mode, since it is not the default.
+        /// </summary>
+        public static SequenceContextMode Async { get; } = new SequenceAsyncContextMode();
+
+        private SequenceContextMode()
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the currently active ambient sequence.
+        /// </summary>
+        internal abstract Sequence ActiveSequence { get; set; }
+
+        private sealed class SequenceThreadContextMode : SequenceContextMode
+        {
+            [ThreadStatic]
+            private static Sequence activeSequence;
+
+            internal override Sequence ActiveSequence
+            {
+                get => SequenceThreadContextMode.activeSequence;
+                set => SequenceThreadContextMode.activeSequence = value;
+            }
+        }
+
+        private sealed class SequenceAsyncContextMode : SequenceContextMode
+        {
+#if FEATURE_ASYNCLOCAL
+            private static AsyncLocal<Sequence> activeSequence = new AsyncLocal<Sequence>();
+
+            internal override Sequence ActiveSequence
+            {
+                get => SequenceAsyncContextMode.activeSequence.Value;
+                set => SequenceAsyncContextMode.activeSequence.Value = value;
+            }
+#elif FEATURE_CALLCONTEXT
+            private const string activeSequenceDataId = "Moq.Sequences.SequenceContextMode+SequenceAsyncContextMode.ActiveSequence";
+
+            internal override Sequence ActiveSequence
+            {
+                get => CallContext.LogicalGetData(activeSequenceDataId) as Sequence;
+                set => CallContext.LogicalSetData(activeSequenceDataId, value);
+            }
+#endif
+        }
+    }
+}


### PR DESCRIPTION
This adds a new global switch `Sequence.ContextMode` to the library that can be used to make its behavior compatible with `Task`-based concurrency and `async` / `await`. It should resolve #17.