### PR TITLE
Update Moq package dependency to 4.11.0 & fix regression

### DIFF
--- a/src/Moq.Sequences.Tests/Moq.Sequences.Tests.csproj
+++ b/src/Moq.Sequences.Tests/Moq.Sequences.Tests.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.7.0" />
+    <PackageReference Include="Moq" Version="4.11.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>

--- a/src/Moq.Sequences/Moq.Sequences.csproj
+++ b/src/Moq.Sequences/Moq.Sequences.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <Version>2.1.0</Version>
     <Authors>Declan Whelan</Authors>
     <Copyright>© 2010 Declan Whelan</Copyright>
@@ -12,7 +12,7 @@
     <RepositoryUrl>https://github.com/dwhelan/Moq-Sequences.git</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
     <PackageReleaseNotes>Added support for Task-based concurrency and async / await.</PackageReleaseNotes>
-    <PackageTags>moq mock .net45 netstandard1.3</PackageTags>
+    <PackageTags>moq mock .net45 netstandard2.0</PackageTags>
     <AssemblyVersion>2.1.0.0</AssemblyVersion>
     <FileVersion>2.1.0.0</FileVersion>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -21,12 +21,12 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <DefineConstants>$(DefineConstants);FEATURE_CALLCONTEXT</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <DefineConstants>$(DefineConstants);FEATURE_ASYNCLOCAL</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Moq" Version="4.7.0" />
+    <PackageReference Include="Moq" Version="4.11.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Moq.Sequences/Step.cs
+++ b/src/Moq.Sequences/Step.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Text;
 
 namespace Moq.Sequences
 {
@@ -6,21 +7,17 @@ namespace Moq.Sequences
     {
         private readonly Times expectedCount;
         private readonly string action;
-        private readonly int maxCount;
         private int actualCount;
 
         internal bool Started { get { return actualCount > 0; } }
         internal bool Complete { get; private set; }
 
-        private static readonly FieldInfo to = typeof(Times).GetField("to", BindingFlags.Instance | BindingFlags.NonPublic);
-        private static readonly MethodInfo verify = typeof(Times).GetMethod("Verify", BindingFlags.Instance | BindingFlags.NonPublic);
         private static readonly MethodInfo getExceptionMessage = typeof(Times).GetMethod("GetExceptionMessage", BindingFlags.Instance | BindingFlags.NonPublic);
 
         internal Step(Times expectedCount, string action = "")
         {
             this.expectedCount = expectedCount;
             this.action = action;
-            maxCount = (int)to.GetValue(expectedCount);
         }
 
         internal void CountCall()
@@ -28,6 +25,7 @@ namespace Moq.Sequences
             if (Complete)
                 throw new SequenceException(this + " is not invokable because it has already completed.");
 
+            var (_, maxCount) = expectedCount;
             if (++actualCount > maxCount)
                 throw new SequenceException(GetFailureMessage("Exceeded maximum number of invocations."));
         }
@@ -42,12 +40,17 @@ namespace Moq.Sequences
 
         private bool Verified()
         {
-            return (bool) verify.Invoke(expectedCount, new[] { (object)actualCount });
+            var (minCount, maxCount) = expectedCount;
+            return minCount <= actualCount && actualCount <= maxCount;
         }
         
         protected virtual string GetFailureMessage(string failMessage)
         {
-            return (string) getExceptionMessage.Invoke(expectedCount, new object[] { failMessage, ToString(), actualCount });
+            var message = new StringBuilder();
+            message.AppendLine(failMessage);
+            message.Append((string)getExceptionMessage.Invoke(expectedCount, new object[] { actualCount }));
+            message.AppendLine(action);
+            return message.ToString();
         }
 
         internal virtual void Reset()


### PR DESCRIPTION
Resolves #22. This also changes the supported version of .NET Standard from 1.3 to 2.0 (by necessity, since Moq 4.11.0 no longer supports .NET Standard 1.x).